### PR TITLE
feat: implement Registry#getState closes #20

### DIFF
--- a/packages/typeless/__tests__/registry.test.ts
+++ b/packages/typeless/__tests__/registry.test.ts
@@ -1,4 +1,5 @@
 import { Registry } from '../src/Registry';
+import { ChainedReducer } from '../src/ChainedReducer';
 
 let registry: Registry;
 
@@ -15,5 +16,27 @@ describe('getDisplayName', () => {
   it('should return with hash', () => {
     expect(registry.getDisplayName(Symbol('module'))).toEqual('module');
     expect(registry.getDisplayName(Symbol('module'))).toEqual('module#2');
+  });
+});
+
+describe('getState', () => {
+  it("sholud return all of store's state", () => {
+    const expected = {
+      'module': { foo: 'fooState' },
+      'module#2': { baz: 'bazState' },
+    };
+    const store = registry.getStore(Symbol('module'));
+    store.enable({
+      epic: null,
+      reducer: new ChainedReducer(expected.module).asReducer(),
+    });
+    store.initState();
+    const store2 = registry.getStore(Symbol('module'));
+    store2.enable({
+      epic: null,
+      reducer: new ChainedReducer(expected['module#2']).asReducer(),
+    });
+    store2.initState();
+    expect(registry.getState()).toStrictEqual(expected);
   });
 });

--- a/packages/typeless/src/Registry.ts
+++ b/packages/typeless/src/Registry.ts
@@ -56,13 +56,13 @@ export class Registry {
         stateLogger = new StateLogger(this.stores);
       }
       if (stateLogger) {
-        stateLogger.calcState('prev');
+        stateLogger.setState('prevState', this.getState());
       }
       for (const store of this.stores) {
         store.dispatch(action, notify);
       }
       if (stateLogger) {
-        stateLogger.calcState('next');
+        stateLogger.setState('nextState', this.getState());
         stateLogger.log(action);
       }
       for (const fn of notify.handlers) {
@@ -70,6 +70,16 @@ export class Registry {
       }
       this.input$.next(action as Action);
     });
+  }
+
+  getState() {
+    const state: Record<string, any> = {};
+    for (const store of this.stores) {
+      if (store.state !== undefined) {
+        state[store.displayName] = store.state;
+      }
+    }
+    return state;
   }
 
   private initStreams() {

--- a/packages/typeless/src/StateLogger.ts
+++ b/packages/typeless/src/StateLogger.ts
@@ -12,17 +12,14 @@ export class StateLogger {
 
   constructor(private stores: Array<Store<any>>) {}
 
-  calcState(type: 'prev' | 'next') {
-    const state = type === 'prev' ? this.prevState : this.nextState;
-    if (type === 'next') {
+  setState(type: 'prevState' | 'nextState', state: any) {
+    if (type === 'nextState') {
       this.end = Date.now();
     }
-    for (const store of this.stores) {
-      if (store.state !== undefined) {
-        state[store.displayName] = store.state;
-      }
-    }
-    if (type === 'prev') {
+
+    this[type] = state;
+
+    if (type === 'prevState') {
       this.start = Date.now();
     }
   }


### PR DESCRIPTION
This is useful for implementation like a redux middleware.

```typescript
class MyRegistry extends Registry {
  dispatch(action: ActionLike) {
    // some implementation of middleware using all of store's state!
    logForCrashReporter(action, this.getState())

    super.dispatch(action);
  }
}
```