### PR TITLE
Fix/incorrect inference in non strict null checks env

### DIFF
--- a/packages/typeless/src/createModule.ts
+++ b/packages/typeless/src/createModule.ts
@@ -17,7 +17,7 @@ export type ConvertAC<T> = T extends null
   : T extends AnyFn
   ? T
   : never;
-export type ConvertActions<T> = { [P in keyof T]: ConvertAC<T[P]> };
+export type ActionCreators<T> = { [P in keyof T]: ConvertAC<T[P]> };
 
 export type ActionMap = { [name: string]: Nullable<(...args: any[]) => {}> };
 
@@ -36,7 +36,7 @@ export interface Handle {
 type ModuleBase = [Handle] & {
   withActions<T extends ActionMap>(
     actionMap: T
-  ): ModuleWithActions<ConvertActions<T>>;
+  ): ModuleWithActions<ActionCreators<T>>;
   withState<TState>(): ModuleWithState<TState>;
 };
 
@@ -50,7 +50,7 @@ type ModuleWithState<TState> = [
 ] & {
   withActions<T extends ActionMap>(
     actionMap: T
-  ): ModuleWithActionsAndState<TState, ConvertActions<T>>;
+  ): ModuleWithActionsAndState<TState, ActionCreators<T>>;
 };
 
 type ModuleWithActionsAndState<TState, TActions> = [

--- a/packages/typeless/src/createModule.ts
+++ b/packages/typeless/src/createModule.ts
@@ -12,12 +12,11 @@ export type Nullable<T> = T | null;
 
 export type AnyFn = (...args: any[]) => any;
 
-export type ConvertAC<T> = false extends T
+export type ConvertAC<T> = T extends null
   ? () => {}
   : T extends AnyFn
   ? T
-  : () => {};
-
+  : never;
 export type ConvertActions<T> = { [P in keyof T]: ConvertAC<T[P]> };
 
 export type ActionMap = { [name: string]: Nullable<(...args: any[]) => {}> };


### PR DESCRIPTION
### Summary

This PR fixes `ActionCreator`'s incorrect inference in `strictNullChecks:false`
This bug causes compile error when call Action which has no payload created by `typeless-form's `createForm` (e.g. `submit` )

### Reproduction

Set `strictNullChecks: false` and Compile following example

```ts
import { createForm } from 'typeless-form';

export const [_, Actions] = createForm<{}>({
  symbol: Symbol(),
});
Actions.submit();  // compile error! `submit` assigned `null` type
```

### Testing at playground

I think `ConvertAC<T>` should infer following list

|Argument type|ActionCretaor type|
|:--|:--|
|`null`|`()=>{}`|
|`AnyFn`|`AnyFn`|
|other|`never`|

---

test `strictNullChecks: true`

http://www.typescriptlang.org/play/#code/PTAEGcBcCcEsGNIDkCuAbNBhAFgU3gNaizigwq4BQlIoARrgGYD20uoluAHgA6uRkAnj3YBBAHaCAYuNABeUAAoAdKoCG0AObgAXKDWSA2gF0AlPIB8+yQG5q3PtAGRh7TM3EA3XE9GYAPAAqVgqMamjg7NyQuOIAJqSBlKCgAPxK5nJWAN4AvsmgeoGg0bEJoBLS4gXpSSl6ipk5uXaU8B5Q1oIAauF6BoLyoADkw63t4p3i6GiiiLAeeu5ePpB+-tMYIV29aHabs-MejSm07dBsiAA0ZNgkQiLEpAAGJ1mgec-UE50A7rCQbAABTUgjQzDUcTmkAW4iWHm8vgCihYzD0UDg4k0TQ+oFR6JgsCxoFy2wGu0o-0BILBEKhR3EilG5lAZ1Yl0gN0B9xcj3ur3xEEJWJx2TxzDRQsxmhJXzaHQEuAiuGhsPhKyR-gxRM0ZMkuzsSsiquOLLZF3wnPoKGcd1I9xQ4gcltwcXouGwak8C2g4t9ah4PDQCDUMI8ylAAElbkSiOBsMx0G6GMRxIwfK7QM8nYi5TQwGpGDFoPZePwHm4Eas-KIiz4gttiqV4qQDgUUuk3s124VQE2uDEWxVJDIe7Ue3ocz5xgrQAcTeJa8X1Yi1pgl-WDnqeuF9jMFxvoCdWWBzhyuXaK08s12Prk5T8BFTgaDwZCD3XoCvq+vP-4URKBLSqK4qStqxKkkM5LhJSAIvrS74MoeTLDGap7spaF48q414CoBUo6iBgrgTK97fLORoqkhn7fkih5asKupQfqu6cMqH7Fse5rnjGpC8uw-JTtAXxAA

---

test `strictNullChecks: false`

http://www.typescriptlang.org/play/?strictNullChecks=false#code/PTAEGcBcCcEsGNIDkCuAbNBhAFgU3gNaizigwq4BQlIoARrgGYD20uoluAHgA6uRkAnj3YBBAHaCAYuNABeUAAoAdKoCG0AObgAXKDWSA2gF0AlPIB8+yQG5q3PtAGRh7TM3EA3XE9GYAPAAqVgqMamjg7NyQuOIAJqSBlKCgAPxK5nJWAN4AvsmgeoGg0bEJoBLS4gXpSSl6ipk5uXaU8B5Q1oIAauF6BoLyoADkw63t4p3i6GiiiLAeeu5ePpB+-tMYIV29aHabs-MejSm0sOLt0GyIAIQcKQ+PT7SB2CRCIsSkAAYH3-T4NQoSKgX4zEpcGLxUiVGT-NiQFDQSZkaAUUAAdzwsigcEQqAwOHwBFI7zCEVwN2oE06GNgkGwAAU1II0Mw1HE5pAFuIlh5vL4AooWMw9LjzpomqBsqARWKYBLQLltgNdpQ6Qzmaz2ZyjuJFKNzKBaJdrpAADRkN6kFyfd7fYXMUUQBXiSWWaWyp3yuBupXfakdAS4Clcnl8laC-zit0qyS7OwhyJh45Gk2sM2WugoZzWr6gFDiBz4GJxAHYNSeBbQL01tQ8HhoBBqbkeZSgACSVvORHA2GY6DLDGI4kYPlwZd+uAFAeotDUjBi0HsvH4Hzc-NWflEi58QW2xVK0NABwKKXSJyy0vyjyKEKh5Vh1UetTPhRP0584yDJ5mKfEO5LhGAprJggF7gccY9OE+x-nq4HQCcxpgKaJaWgy7y2uw9qXs0s40gIGpMiybIcv+CHAVuYG7tA-iOs6MbuleMpyi6vqaEqUFqkRWqkbqrYATRBrDGmKEZmh3Y2q4+YOqxjFSix3psYquT4T+Sa4ORNGUYKCHRq6mhcTBnChvBQmiaAqGIOheZYTJRYzpQQA