### PR TITLE
fix: define DefaultTypelessProvider's type using React.FC

### DIFF
--- a/packages/typeless/src/TypelessContext.tsx
+++ b/packages/typeless/src/TypelessContext.tsx
@@ -7,15 +7,11 @@ export const TypelessContext = React.createContext(null as null | {
 
 export const defaultRegistry = new Registry();
 
-export function DefaultTypelessProvider({
-  children,
-}: {
-  children: React.ReactChild;
-}) {
+export const DefaultTypelessProvider: React.FC = ({ children }) => {
   const value = React.useMemo(() => ({ registry: defaultRegistry }), []);
   return (
     <TypelessContext.Provider value={value}>
       {children}
     </TypelessContext.Provider>
   );
-}
+};


### PR DESCRIPTION
This PR fixes compile error in following case

```tsx
const AppProvider:React.FC = (props) => {
  return <DefaultTypelessProvider>{props.children}</DefaultTypelessProvider>;
};
```

This causes following compile error.

```
Type 'ReactNode' is not assignable to type 'ReactChild'.
  Type 'undefined' is not assignable to type 'ReactChild'.ts(2322)
TypelessContext.d.ts(8, 5): The expected type comes from property 'children' which is declared here on type 'IntrinsicAttributes & { children: ReactChild; }'
```

I think `DefaultTypelessProvider`'s type should be `React.FC`
