### PR TITLE
Feature: allow Promise<ActionLike[]> to be assigned EpicResult

### DIFF
--- a/packages/typeless/src/Epic.ts
+++ b/packages/typeless/src/Epic.ts
@@ -86,19 +86,17 @@ export class Epic {
     return this.getHandlers(sourceAction).map(handler => {
       return defer(() => {
         log();
-        const result = handler(sourceAction.payload, deps, sourceAction) as (
-          | Observable<Action>
-          | Action
-          | Action[]);
+        const result = handler(sourceAction.payload, deps, sourceAction);
         if (Array.isArray(result)) {
           return from(result);
         }
-        if (isAction(result)) {
+        if (isAction(result) || result === null) {
           return of(result);
         }
+
         return result;
       }).pipe(
-        mergeMap((action: Action) => {
+        mergeMap((action: unknown) => {
           if (action === null) {
             // ignore if action is null
             return empty();


### PR DESCRIPTION
### Motivation

This feature makes implementation simplify in this case.

```typescript
epic
  .on(Actions.start, ()=> Promise.resolve(Actions.bridge()))
  .on(Actions.bridge, () => [Actions.next1(), Actions.next2()])
```

### Note

`EpicResult` can be assigned not only `Promise<ActionLike[]>` but `Observable<ActionLike[]>`.
I think this is better because consistent.